### PR TITLE
Add different variants of Courier Prime filenames

### DIFF
--- a/pkg/pdf/fonts.go
+++ b/pkg/pdf/fonts.go
@@ -27,13 +27,13 @@ type Font struct {
 var (
 	CourierPrime = Font{
 		RomanName:      "Courier Prime",
-		Roman:          []string{"Courier Prime.ttf", "Courier Prime Regular.ttf"},
+		Roman:          []string{"Courier Prime.ttf", "Courier Prime Regular.ttf", "CourierPrime-Regular.ttf", "courier-prime.ttf"},
 		BoldName:       "Courier Prime Bold",
-		Bold:           []string{"Courier Prime Bold.ttf"},
+		Bold:           []string{"Courier Prime Bold.ttf", "CourierPrime-Bold.ttf", "courier-prime-bold.ttf"},
 		ItalicName:     "Courier Prime Italic",
-		Italic:         []string{"Courier Prime Italic.ttf"},
+		Italic:         []string{"Courier Prime Italic.ttf", "CourierPrime-Italic.ttf", "courier-prime-italic.ttf"},
 		BoldItalicName: "Courier Prime Bold Italic",
-		BoldItalic:     []string{"Courier Prime Bold Italic.ttf"},
+		BoldItalic:     []string{"Courier Prime Bold Italic.ttf", "CourierPrime-BoldItalic.ttf", "courier-prime-bold-italic.ttf"},
 	}
 
 	CourierNew = Font{


### PR DESCRIPTION
### Description of the change

Add more variants to Courier Prime. The [official sources](https://github.com/quoteunquoteapps/CourierPrime/tree/master/fonts/ttf) are named like `CourierPrime-Regular.ttf`, same for when you get it from [Google Fonts](https://fonts.google.com/specimen/Courier+Prime). Also added another variant I saw in the wild. As an alternative you could do more text processing, removing spaces and adding hyphens, but I figure this is simple and works well enough.

This may be less necessary if the upstream font finder package you use [switches to `fc-match`](https://github.com/flopp/go-findfont/issues/7). For example:
```sh
❯ fc-match "Courier Prime"
CourierPrime-Regular.ttf: "Courier Prime" "Regular"
```

### Benefits

Most optimal font is more likely to be found.

### Possible drawbacks

None?

### Applicable issues

None.