### PR TITLE
Add a Spanish translation

### DIFF
--- a/pkg/languages/languages.go
+++ b/pkg/languages/languages.go
@@ -71,6 +71,12 @@ func GetLanguage(alias string) Language {
 
 		return Italian
 
+    case
+        "spanish",
+        "español":
+
+        return Spanish
+
 	default:
 		return Default
 	}

--- a/pkg/languages/languages.go
+++ b/pkg/languages/languages.go
@@ -28,6 +28,7 @@ const (
 	French
 	German
 	Italian
+    Spanish
 )
 
 // Default language is English

--- a/pkg/languages/languages.go
+++ b/pkg/languages/languages.go
@@ -28,7 +28,7 @@ const (
 	French
 	German
 	Italian
-    Spanish
+	Spanish
 )
 
 // Default language is English
@@ -71,12 +71,12 @@ func GetLanguage(alias string) Language {
 
 		return Italian
 
-    case
-        "spanish",
-        "espanol", // ñ is hard to find too...
-        "español":
+	case
+		"spanish",
+		"espanol", // ñ is hard to find too...
+		"español":
 
-        return Spanish
+		return Spanish
 
 	default:
 		return Default
@@ -101,6 +101,9 @@ func (lang Language) String() string {
 	case Italian:
 		return "Italian"
 
+	case Spanish:
+		return "Spanish"
+
 	default:
 		panic("unknown language")
 	}
@@ -123,6 +126,9 @@ func (lang Language) Translation() Translation {
 
 	case Italian:
 		return ItalianTranslation
+
+	case Spanish:
+		return SpanishTranslation
 
 	default:
 		panic("unknown language")

--- a/pkg/languages/languages.go
+++ b/pkg/languages/languages.go
@@ -73,6 +73,7 @@ func GetLanguage(alias string) Language {
 
     case
         "spanish",
+        "espanol", // ñ is hard to find too...
         "español":
 
         return Spanish

--- a/pkg/languages/spanish.go
+++ b/pkg/languages/spanish.go
@@ -7,7 +7,7 @@ var SpanishTranslation = Translation{
 
 	SceneTags: []string{
         "int ", "ext ", "est ", "int./ext ", "int/ext ", "i/e ", "i./e ",
-		"int.", "ext.", "est.", "int./ext.", "int/ext.", "i/e.", "i./e.",
+        "int.", "ext.", "est.", "int./ext.", "int/ext.", "i/e.", "i./e.",
 	},
 
 	StageplaySceneTags: []string{

--- a/pkg/languages/spanish.go
+++ b/pkg/languages/spanish.go
@@ -1,13 +1,12 @@
 package languages
 
 // SpanishTranslation is the Spanish translation of Wrap
-
 var SpanishTranslation = Translation{
 	Language: Spanish,
 
 	SceneTags: []string{
-        "int ", "ext ", "est ", "int./ext ", "int/ext ", "i/e ", "i./e ",
-        "int.", "ext.", "est.", "int./ext.", "int/ext.", "i/e.", "i./e.",
+		"int ", "ext ", "est ", "int./ext ", "int/ext ", "i/e ", "i./e ",
+		"int.", "ext.", "est.", "int./ext.", "int/ext.", "i/e.", "i./e.",
 	},
 
 	StageplaySceneTags: []string{

--- a/pkg/languages/spanish.go
+++ b/pkg/languages/spanish.go
@@ -1,0 +1,32 @@
+package languages
+
+// SpanishTranslation is the Spanish translation of Wrap
+
+var SpanishTranslation = Translation{
+	Language: Spanish,
+
+	SceneTags: []string{
+        "int ", "ext ", "est ", "int./ext ", "int/ext ", "i/e ", "i./e ",
+		"int.", "ext.", "est.", "int./ext.", "int/ext.", "i/e.", "i./e.",
+	},
+
+	StageplaySceneTags: []string{
+		"scene ", "escena ",
+	},
+
+	TransitionTags: []string{
+		" TO:", " A:",
+	},
+
+	BeginActTags: []string{
+		"ACTO ",
+	},
+
+	EndActTags: []string{
+		"FIN DE ACTO ",
+	},
+
+	More: "(MÁS)",
+
+	Contd: "(CONTINÚA)",
+}


### PR DESCRIPTION
### Spanish language

This pull request adds a Spanish language file and enables it as "spanish", "español" and "espanol", following the patterns used for the french language.

### Benefits

Support for one more language.