### PR TITLE
Specify actual font name in PDF

### DIFF
--- a/pkg/pdf/fonts.go
+++ b/pkg/pdf/fonts.go
@@ -65,6 +65,8 @@ var AutoFontSelection = true
 // SelectedFont is the font to be used during export if AutoSelect is disabled
 var SelectedFont = CourierPrime
 
+var LoadedFont Font
+
 func findFont(fonts []string) (string, error) {
 	for _, font := range fonts {
 		path, err := findfont.Find(font)
@@ -116,19 +118,20 @@ func loadFont(font Font) error {
 	}
 
 	// Successfully found the font
-	thisPDF.AddTTFFont("courier", pathToRegular)
+	LoadedFont = font
+	thisPDF.AddTTFFont(LoadedFont.RomanName, pathToRegular)
 
-	thisPDF.AddTTFFontWithOption("courier", pathToBold,
+	thisPDF.AddTTFFontWithOption(LoadedFont.RomanName, pathToBold,
 		gopdf.TtfOption{
 			Style: gopdf.Bold,
 		})
 
-	thisPDF.AddTTFFontWithOption("courier", pathToItalic,
+	thisPDF.AddTTFFontWithOption(LoadedFont.RomanName, pathToItalic,
 		gopdf.TtfOption{
 			Style: gopdf.Italic,
 		})
 
-	thisPDF.AddTTFFontWithOption("courier", pathToBoldItalic,
+	thisPDF.AddTTFFontWithOption(LoadedFont.RomanName, pathToBoldItalic,
 		gopdf.TtfOption{
 			Style: gopdf.Italic | gopdf.Bold,
 		})
@@ -173,9 +176,9 @@ func loadFonts() {
 }
 
 func setDefaultFont() {
-	thisPDF.SetFont("courier", "", fontSize)
+	thisPDF.SetFont(LoadedFont.RomanName, "", fontSize)
 }
 
 func setStyledFont(style string) {
-	thisPDF.SetFont("courier", style, fontSize)
+	thisPDF.SetFont(LoadedFont.RomanName, style, fontSize)
 }


### PR DESCRIPTION
### Description of the change

Uses the font's name as the name of the embedded font instead of the currently hard-coded `courier`.

### Benefits

More clear what font is _actually_ embedded in the PDF. Visually I was pretty sure it was Courier Prime, but the name of the font in the PDF data was just "courier" so I thought maybe it was not finding the right font.

Before:

```
❯ pdffonts ~/scripts/test.pdf
name                                 type              encoding         emb sub uni object ID
------------------------------------ ----------------- ---------------- --- --- --- ---------
courier                              CID TrueType      Identity-H       yes no  yes      9  0
courier                              CID TrueType      Identity-H       yes no  yes     14  0
courier                              CID TrueType      Identity-H       yes no  yes     19  0
courier                              CID TrueType      Identity-H       yes no  yes     24  0
```

After:

```
❯ pdffonts ~/scripts/test.pdf
name                                 type              encoding         emb sub uni object ID
------------------------------------ ----------------- ---------------- --- --- --- ---------
Courier+Prime                        CID TrueType      Identity-H       yes no  yes      9  0
Courier+Prime                        CID TrueType      Identity-H       yes no  yes     14  0
Courier+Prime                        CID TrueType      Identity-H       yes no  yes     19  0
Courier+Prime                        CID TrueType      Identity-H       yes no  yes     24  0
```

### Possible drawbacks

Only thing I could think of is if there's some weird character issue with the name of some fonts.